### PR TITLE
Update Dockerfile to remove version specification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/alertmanager:v0.20.0
+FROM prom/alertmanager
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
allow docker to pull the latest version of alertmanager rather than specifying a version.